### PR TITLE
fix always appending .json to file names

### DIFF
--- a/innstereo/dialog_windows.py
+++ b/innstereo/dialog_windows.py
@@ -672,7 +672,7 @@ class FileChooserSave(object):
         If the file already exists a dialog will confirm the overwrite.
         """
         self.filename = self.dialog.get_filename()
-        if self.filename[-5:] is not ".json":
+        if self.filename[-5:] != ".json":
             self.filename = self.filename + ".json"
         if os.path.exists(self.filename) == True:
             overwrite = OverwriteDialog(self.write_data, self.dialog)


### PR DESCRIPTION
When saving a project ".json" was always appended. Also to those files that already ended in ".json". This was caused by a false logic operator.