### PR TITLE
Remove newline-characters in file parser dialog

### DIFF
--- a/innstereo/file_parser.py
+++ b/innstereo/file_parser.py
@@ -145,6 +145,7 @@ class FileParseDialog(object):
             if key < start_line:
                 continue
             else:
+                line = line.rstrip()
                 string_list = re.split(r"[;,]", line)
                 self.append_data(string_list)
 


### PR DESCRIPTION
Some CSV files have newline-characters at the end of each line. The file parser dialog displayed these rows as cells with two rows. I fixed the issue by stripping each line-string from all whitespace-characters.