### PR TITLE
Tests for UI, Input validation

### DIFF
--- a/innstereo/dataview_classes.py
+++ b/innstereo/dataview_classes.py
@@ -52,6 +52,14 @@ class DataTreeView(Gtk.TreeView):
         number = round(number, 1)
         return number
 
+    def truncate_vector(self, number):
+        """
+        Rounds and truncates a number to 3 decimal places. Used for vector
+        magnitude.
+        """
+        number = round(number, 3)
+        return number
+
     def set_layer_object(self, lyr_obj):
         """
         Passes a layer object to this class.
@@ -102,6 +110,76 @@ class DataTreeView(Gtk.TreeView):
         """
         if self.settings.get_highlight() is True:
             self.redraw()
+
+    def validate_numeric_input(self, inp, inp_type):
+        """
+        Validates a numeric input.
+
+        Comma decimal places are replaced by dot decimal places. For the
+        different angles the boundaries are checked. Returns the valid
+        number or None.
+        """
+        if inp == "":
+            return 0
+        else:
+            try:
+                inp = float(inp.replace(",", "."))
+            except:
+                return None
+
+        if inp_type == "dir":
+            while inp < 0 or inp > 360:
+                if inp < 0:
+                    inp += 360
+                else:
+                    inp -= 360
+            return inp
+        elif inp_type == "dip":
+            if inp < 0 or inp > 90:
+                return None
+            else:
+                return inp
+        elif inp_type == "vector":
+            if inp < 0 or inp > 1:
+                return None
+            else:
+                return inp
+        elif inp_type == "angle":
+            if inp < 0 or inp > 360:
+                return None
+            else:
+                return inp
+
+    def validate_sense(self, inp):
+        """
+        Validates the movement or shear sense.
+
+        The column accepts a set of valid strings or numbers that are
+        replaced with the valid strings. Returns the valid string or None.
+        """
+        val_inp = ["", "uk", "up", "dn", "dex", "sin"]
+
+        try:
+            inp = int(inp)
+            if inp == 0:
+                sense = "uk"
+            elif inp == 1:
+                sense = "up"
+            elif inp == 2:
+                sense = "dn"
+            elif inp == 3:
+                sense = "dex"
+            elif inp == 4:
+                sense = "sin"
+            else:
+                sense = None
+            return sense
+        except:
+            if inp in val_inp:
+                return str(inp)
+            else:
+                return None
+
 
 class PlaneDataView(DataTreeView):
 
@@ -159,8 +237,13 @@ class PlaneDataView(DataTreeView):
         The function replaces a ","- with a "."-comma. Converts
         the string value to a float.
         """
-        self.store[path][0] = float(new_string.replace(",", "."))
-        self.redraw()
+        new_number = self.validate_numeric_input(new_string, "dir")
+        if new_number is not None:
+            self.store[path][0] = new_number
+            self.redraw()
+            return new_number
+        else:
+            return None
 
     def renderer_dip_edited(self, widget, path, new_string):
         """
@@ -168,8 +251,13 @@ class PlaneDataView(DataTreeView):
         The function replaces a ","- with a "."-comma. Converts
         the string value to a float.
         """
-        self.store[path][1] = float(new_string.replace(",", "."))
-        self.redraw()
+        new_number = self.validate_numeric_input(new_string, "dip")
+        if new_number is not None:
+            self.store[path][1] = new_number
+            self.redraw()
+            return new_number
+        else:
+            return None
 
     def renderer_strat_edited(self, widget, path, new_string):
         """
@@ -178,6 +266,7 @@ class PlaneDataView(DataTreeView):
         """
         self.store[path][2] = new_string
         self.redraw()
+
 
 class FaultPlaneDataView(DataTreeView):
 
@@ -262,8 +351,13 @@ class FaultPlaneDataView(DataTreeView):
         The function replaces a ","- with a "."-comma. Converts
         the string value to a float.
         """
-        self.store[path][0] = float(new_string.replace(",", "."))
-        self.redraw()
+        new_number = self.validate_numeric_input(new_string, "dir")
+        if new_number is not None:
+            self.store[path][0] = new_number
+            self.redraw()
+            return new_number
+        else:
+            return None
 
     def renderer_dip_edited(self, widget, path, new_string):
         """
@@ -271,8 +365,13 @@ class FaultPlaneDataView(DataTreeView):
         The function replaces a ","- with a "."-comma. Converts
         the string value to a float.
         """
-        self.store[path][1] = float(new_string.replace(",", "."))
-        self.redraw()
+        new_number = self.validate_numeric_input(new_string, "dip")
+        if new_number is not None:
+            self.store[path][1] = new_number
+            self.redraw()
+            return new_number
+        else:
+            return None
 
     def renderer_ldir_edited(self, widget, path, new_string):
         """
@@ -280,8 +379,13 @@ class FaultPlaneDataView(DataTreeView):
         The function replaces a ","- with a "."-comma. Converts
         the string value to a float.
         """
-        self.store[path][2] = float(new_string.replace(",", "."))
-        self.redraw()
+        new_number = self.validate_numeric_input(new_string, "dir")
+        if new_number is not None:
+            self.store[path][2] = new_number
+            self.redraw()
+            return new_number
+        else:
+            return None
 
     def renderer_ldip_edited(self, widget, path, new_string):
         """
@@ -289,16 +393,27 @@ class FaultPlaneDataView(DataTreeView):
         The function replaces a ","- with a "."-comma. Converts
         the string value to a float.
         """
-        self.store[path][3] = float(new_string.replace(",", "."))
-        self.redraw()
+        new_number = self.validate_numeric_input(new_string, "dip")
+        if new_number is not None:
+            self.store[path][3] = new_number
+            self.redraw()
+            return new_number
+        else:
+            return None
 
     def renderer_sense_edited(self, widget, path, new_string):
         """
         If the linear shear sense is edited, replace the existing value.
         The the values is replaced by the raw input-string.
         """
-        self.store[path][4] = new_string
-        self.redraw()
+        new_string = self.validate_sense(new_string)
+        if new_string is not None:
+            self.store[path][4] = new_string
+            self.redraw()
+            return new_string
+        else:
+            return None
+
 
 class LineDataView(DataTreeView):
 
@@ -359,8 +474,13 @@ class LineDataView(DataTreeView):
         The function replaces a ","- with a "."-comma. Converts
         the string value to a float.
         """
-        self.store[path][0] = float(new_string.replace(",", "."))
-        self.redraw()
+        new_number = self.validate_numeric_input(new_string, "dir")
+        if new_number is not None:
+            self.store[path][0] = new_number
+            self.redraw()
+            return new_number
+        else:
+            return None
 
     def renderer_dip_edited(self, widget, path, new_string):
         """
@@ -368,16 +488,27 @@ class LineDataView(DataTreeView):
         The function replaces a ","- with a "."-comma. Converts
         the string value to a float.
         """
-        self.store[path][1] = float(new_string.replace(",", "."))
-        self.redraw()
+        new_number = self.validate_numeric_input(new_string, "dip")
+        if new_number is not None:
+            self.store[path][1] = new_number
+            self.redraw()
+            return new_number
+        else:
+            return None
 
     def renderer_sense_edited(self, widget, path, new_string):
         """
         If the sense of the linear is edited, replace the existing value.
         The new values is the raw input-string.
         """
-        self.store[path][2] = new_string
-        self.redraw()
+        new_string = self.validate_sense(new_string)
+        if new_string is not None:
+            self.store[path][2] = new_string
+            self.redraw()
+            return new_string
+        else:
+            return None
+
 
 class SmallCircleDataView(DataTreeView):
 
@@ -440,8 +571,13 @@ class SmallCircleDataView(DataTreeView):
         The function replaces a ","- with a "."-comma. Converts
         the string value to a float.
         """
-        self.store[path][0] = float(new_string.replace(",", "."))
-        self.redraw()
+        new_number = self.validate_numeric_input(new_string, "dir")
+        if new_number is not None:
+            self.store[path][0] = new_number
+            self.redraw()
+            return new_number
+        else:
+            return None
 
     def renderer_dip_edited(self, widget, path, new_string):
         """
@@ -449,8 +585,13 @@ class SmallCircleDataView(DataTreeView):
         The function replaces a ","- with a "."-comma. Converts
         the string value to a float.
         """
-        self.store[path][1] = float(new_string.replace(",", "."))
-        self.redraw()
+        new_number = self.validate_numeric_input(new_string, "dip")
+        if new_number is not None:
+            self.store[path][1] = new_number
+            self.redraw()
+            return new_number
+        else:
+            return None
 
     def renderer_angle_edited(self, widget, path, new_string):
         """
@@ -458,8 +599,13 @@ class SmallCircleDataView(DataTreeView):
         The function replaces a ","- with a "."-comma. Converts
         the string value to a float.
         """
-        self.store[path][2] = float(new_string.replace(",", "."))
-        self.redraw()
+        new_number = self.validate_numeric_input(new_string, "angle")
+        if new_number is not None:
+            self.store[path][2] = new_number
+            self.redraw()
+            return new_number
+        else:
+            return None
 
 
 class EigenVectorView(DataTreeView):
@@ -512,7 +658,7 @@ class EigenVectorView(DataTreeView):
         column_value.set_cell_data_func(renderer_value, 
                     lambda col, cell, model, iter, unused:
                     cell.set_property("text",
-                    "{0}".format(self.truncate(model.get(iter, 2)[0]))))
+                    "{0}".format(self.truncate_vector(model.get(iter, 2)[0]))))
         self.append_column(column_value)
 
         renderer_dir.connect("edited", self.renderer_dir_edited)
@@ -525,8 +671,13 @@ class EigenVectorView(DataTreeView):
         The function replaces a ","- with a "."-comma. Converts
         the string value to a float.
         """
-        self.store[path][0] = float(new_string.replace(",", "."))
-        self.redraw()
+        new_number = self.validate_numeric_input(new_string, "dir")
+        if new_number is not None:
+            self.store[path][0] = new_number
+            self.redraw()
+            return new_number
+        else:
+            return None
 
     def renderer_dip_edited(self, widget, path, new_string):
         """
@@ -534,8 +685,13 @@ class EigenVectorView(DataTreeView):
         The function replaces a ","- with a "."-comma. Converts
         the string value to a float.
         """
-        self.store[path][1] = float(new_string.replace(",", "."))
-        self.redraw()
+        new_number = self.validate_numeric_input(new_string, "dip")
+        if new_number is not None:
+            self.store[path][1] = new_number
+            self.redraw()
+            return new_number
+        else:
+            return None
 
     def renderer_value_edited(self, widget, path, new_string):
         """
@@ -544,5 +700,10 @@ class EigenVectorView(DataTreeView):
         The new value is converted to a float and commas are replaced by
         dots. Then the new value is assigned to the cell.
         """
-        self.store[path][2] = float(new_string.replace(",", "."))
-        self.redraw()
+        new_number = self.validate_numeric_input(new_string, "vector")
+        if new_number is not None:
+            self.store[path][2] = new_number
+            self.redraw()
+            return new_number
+        else:
+            return None

--- a/innstereo/layer_types.py
+++ b/innstereo/layer_types.py
@@ -13,6 +13,7 @@ are stored in these classes.
 """
 
 from gi.repository import Gdk, GdkPixbuf
+from collections import OrderedDict
 
 
 class PlaneLayer(object):
@@ -36,7 +37,7 @@ class PlaneLayer(object):
         self.data_treestore = treestore
         self.data_treeview = treeview
 
-        self.props = {"type": "plane",
+        self.props = OrderedDict(sorted({"type": "plane",
                       "label": "Plane layer",
                       "page": 0,
                       #Great circle / Small circle properties
@@ -92,7 +93,7 @@ class PlaneLayer(object):
                       "lower_limit": 1,
                       "upper_limit": 10,
                       "steps": 10
-                      }
+                      }.items()))
         self.props["label"] = _("Plane Layer")
 
     def get_page(self):

--- a/innstereo/main_ui.py
+++ b/innstereo/main_ui.py
@@ -22,6 +22,7 @@ import os
 import csv
 from matplotlib.lines import Line2D
 import json
+from collections import OrderedDict
 
 #Internal imports
 from .dataview_classes import (PlaneDataView, LineDataView,
@@ -246,6 +247,7 @@ class MainWindow(object):
             if lyr_obj is None:
                 #No lyr_obj means that this is a folder
                 folder_props = {"type": "folder", "label": label}
+                folder_props = OrderedDict(sorted(folder_props.items()))
                 copy["layers"].append([path_str, folder_props, []])
             else:
                 properties = lyr_obj.get_properties()
@@ -267,6 +269,7 @@ class MainWindow(object):
                 append_layer(lyr_obj, path_str, label)
 
         self.layer_store.foreach(iterate_over_store, path_str)
+        copy = OrderedDict(sorted(copy.items()))
         data = json.dumps(copy)
         return data
 
@@ -461,6 +464,7 @@ class MainWindow(object):
 
         data = self.copy_layer()
         self.clipboard.set_text(data, -1)
+        return data
 
     def on_toolbutton_paste_clicked(self, toolbutton):
         """
@@ -727,7 +731,7 @@ class MainWindow(object):
 
         self.redraw_plot()
 
-    def on_toolbutton_save_clicked(self, widget):
+    def on_toolbutton_save_clicked(self, widget, testing=False):
         # pylint: disable=unused-argument
         """
         Triggered from the GUI. Saves the project.
@@ -755,6 +759,7 @@ class MainWindow(object):
             if lyr_obj is None:
                 #No lyr_obj means that this is a folder
                 folder_props = {"type": "folder", "label": label}
+                folder_props = OrderedDict(sorted(folder_props.items()))
                 copy["layers"].append([path_str, folder_props, []])
             else:
                 properties = lyr_obj.get_properties()
@@ -774,9 +779,12 @@ class MainWindow(object):
             append_layer(lyr_obj, path_str, label)
 
         self.layer_store.foreach(iterate_over_store)
+        copy = OrderedDict(sorted(copy.items()))
         dump = json.dumps(copy)
-        dlg = FileChooserSave(self.main_window, dump)
-        dlg.run()
+        if testing == False:
+            dlg = FileChooserSave(self.main_window, dump)
+            dlg.run()
+        return dump
 
     def on_toolbutton_open_clicked(self, toolbutton):
         # pylint: disable=unused-argument

--- a/innstereo/plot_control.py
+++ b/innstereo/plot_control.py
@@ -16,6 +16,7 @@ from gi.repository import Gtk, Gdk
 from matplotlib.figure import Figure
 from matplotlib.gridspec import GridSpec
 import mplstereonet
+from collections import OrderedDict
 
 
 class PlotSettings(object):
@@ -40,7 +41,7 @@ class PlotSettings(object):
         """
         self.folder_icon = Gtk.IconTheme.get_default().load_icon(
             "folder", 16, 0)
-        self.props = {"draw_grid": True,
+        self.props = OrderedDict(sorted({"draw_grid": True,
                       "equal_area_projection": True,
                       "minor_grid_spacing": 2,
                       "major_grid_spacing": 10,
@@ -54,7 +55,7 @@ class PlotSettings(object):
                       "draw_legend": True,
                       "canvas_color": "#bfbfbf",
                       "highlight": False
-                      }
+                      }.items()))
         self.night_mode = False
         self.fig = Figure(dpi=self.props["pixel_density"])
 

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -5,6 +5,14 @@ import innstereo
 
 gui = innstereo.startup(testing=True)
 
+def reset_project():
+    """
+    Deletes all layers.
+    """
+    selection = gui.layer_view.get_selection()
+    selection.select_all()
+    gui.on_toolbutton_delete_layer_clicked(widget=None)
+
 def test_create_plane_layer():
     """
     Creates a layer. Asserts whether number of rows is 1.
@@ -68,7 +76,7 @@ def test_create_group_layer_no_selection():
     selection.unselect_all()
     gui.on_toolbutton_create_group_layer_clicked(widget=None)
 
-def test_create_group_layer_with_selectin():
+def test_create_group_layer_with_selection():
     """
     Creates a group layer with a selection.
     """
@@ -87,10 +95,9 @@ def test_add_planar_feature():
     """
     Creates a planar layer and adds an empty row to it.
     """
-    selection = gui.layer_view.get_selection()
-    selection.select_all()
-    gui.on_toolbutton_delete_layer_clicked(widget=None)
+    reset_project()
     store, lyr_obj_new = gui.on_toolbutton_create_plane_dataset_clicked(widget=None)
+    selection = gui.layer_view.get_selection()
     selection.select_path(0)
     gui.on_toolbutton_add_feature_clicked(widget=None)
 
@@ -98,10 +105,9 @@ def test_add_linear_feature():
     """
     Creates a linear layer and adds an empty row to it.
     """
-    selection = gui.layer_view.get_selection()
-    selection.select_all()
-    gui.on_toolbutton_delete_layer_clicked(widget=None)
+    reset_project()
     store, lyr_obj_new = gui.on_toolbutton_create_line_dataset_clicked(widget=None)
+    selection = gui.layer_view.get_selection()
     selection.select_path(0)
     gui.on_toolbutton_add_feature_clicked(widget=None)
 
@@ -109,10 +115,9 @@ def test_add_faultplane_feature():
     """
     Creates a faultplane layer and adds an empty row to it.
     """
-    selection = gui.layer_view.get_selection()
-    selection.select_all()
-    gui.on_toolbutton_delete_layer_clicked(widget=None)
+    reset_project()
     store, lyr_obj_new = gui.on_toolbutton_create_faultplane_dataset_clicked(widget=None)
+    selection = gui.layer_view.get_selection()
     selection.select_path(0)
     gui.on_toolbutton_add_feature_clicked(widget=None)
 
@@ -120,9 +125,132 @@ def test_add_smallcircle_feature():
     """
     Creates a smallcircle layer and adds an empty row to it.
     """
-    selection = gui.layer_view.get_selection()
-    selection.select_all()
-    gui.on_toolbutton_delete_layer_clicked(widget=None)
+    reset_project()
     store, lyr_obj_new = gui.on_toolbutton_create_small_circle_clicked(widget=None)
+    selection = gui.layer_view.get_selection()
     selection.select_path(0)
     gui.on_toolbutton_add_feature_clicked(widget=None)
+
+def test_copy_plane():
+    """
+    Copies a plane layer with one feature and assert the string.
+    """
+    plane_copy = """{"filetype": "InnStereo layer 1.0", "layers": [["0", {"arrow_color": "#d51e1e", "capstyle": "butt", "colormap": "viridis", "contour_label_size": 12, "contour_line_color": "#000000", "contour_line_style": "-", "contour_line_width": 1, "contour_method": "exponential_kamb", "contour_resolution": 40, "contour_sigma": 2, "contour_use_line_color": true, "dip_rose_spacing": 10, "draw_angelier": true, "draw_contour_fills": false, "draw_contour_labels": false, "draw_contour_lines": false, "draw_fisher_sc": false, "draw_gcircles": true, "draw_hoeppener": false, "draw_linears": true, "draw_lp_plane": false, "draw_mean_vector": false, "draw_poles": false, "fisher_conf": 95, "label": "Plane Layer", "line_alpha": 1.0, "line_color": "#0000ff", "line_style": "-", "line_width": 1.0, "lower_limit": 1, "manual_range": false, "marker_alpha": 1.0, "marker_edge_color": "#000000", "marker_edge_width": 1.0, "marker_fill": "#ff7a00", "marker_size": 8.0, "marker_style": "o", "page": 0, "pole_alpha": 1.0, "pole_edge_color": "#000000", "pole_edge_width": 1.0, "pole_fill": "#1abd00", "pole_size": 8.0, "pole_style": "^", "rose_bottom": 0, "rose_spacing": 10, "steps": 10, "type": "plane", "upper_limit": 10}, [[120.0, 30.0, ""]]]]}"""
+    reset_project()
+    store, lyr_obj_new = gui.on_toolbutton_create_plane_dataset_clicked(widget=None)
+    selection = gui.layer_view.get_selection()
+    selection.select_path(0)
+    gui.add_planar_feature(store, 120, 30, "")
+    data = gui.on_toolbutton_copy_clicked(toolbutton=None)
+    assert data == plane_copy
+
+def test_copy_linear():
+    """
+    Copies a line layer with one feature and asserts the string.
+    """
+    line_copy = """{"filetype": "InnStereo layer 1.0", "layers": [["0", {"arrow_color": "#d51e1e", "capstyle": "butt", "colormap": "viridis", "contour_label_size": 12, "contour_line_color": "#000000", "contour_line_style": "-", "contour_line_width": 1, "contour_method": "exponential_kamb", "contour_resolution": 40, "contour_sigma": 2, "contour_use_line_color": true, "dip_rose_spacing": 10, "draw_angelier": true, "draw_contour_fills": false, "draw_contour_labels": false, "draw_contour_lines": false, "draw_fisher_sc": false, "draw_gcircles": true, "draw_hoeppener": false, "draw_linears": true, "draw_lp_plane": false, "draw_mean_vector": false, "draw_poles": false, "fisher_conf": 95, "label": "Linear Layer", "line_alpha": 1.0, "line_color": "#0000ff", "line_style": "-", "line_width": 1.0, "lower_limit": 1, "manual_range": false, "marker_alpha": 1.0, "marker_edge_color": "#000000", "marker_edge_width": 1.0, "marker_fill": "#69b3ff", "marker_size": 8.0, "marker_style": "o", "page": 1, "pole_alpha": 1.0, "pole_edge_color": "#000000", "pole_edge_width": 1.0, "pole_fill": "#1abd00", "pole_size": 8.0, "pole_style": "^", "rose_bottom": 0, "rose_spacing": 10, "steps": 10, "type": "line", "upper_limit": 10}, [[240.0, 60.0, "up"]]]]}"""
+    reset_project()
+    store, lyr_obj_new = gui.on_toolbutton_create_line_dataset_clicked(widget=None)
+    selection = gui.layer_view.get_selection()
+    selection.select_path(0)
+    gui.add_linear_feature(store, 240, 60, "up")
+    data = gui.on_toolbutton_copy_clicked(toolbutton=None)
+    assert data == line_copy
+
+def test_copy_faultplane():
+    """
+    Copies a faultplane layer with one feature and asserts the string.
+    """
+    faultplane_copy = """{"filetype": "InnStereo layer 1.0", "layers": [["0", {"arrow_color": "#d51e1e", "capstyle": "butt", "colormap": "viridis", "contour_label_size": 12, "contour_line_color": "#000000", "contour_line_style": "-", "contour_line_width": 1, "contour_method": "exponential_kamb", "contour_resolution": 40, "contour_sigma": 2, "contour_use_line_color": true, "dip_rose_spacing": 10, "draw_angelier": true, "draw_contour_fills": false, "draw_contour_labels": false, "draw_contour_lines": false, "draw_fisher_sc": false, "draw_gcircles": true, "draw_hoeppener": false, "draw_linears": true, "draw_lp_plane": false, "draw_mean_vector": false, "draw_poles": false, "fisher_conf": 95, "label": "Faultplane Layer", "line_alpha": 1.0, "line_color": "#000000", "line_style": "-", "line_width": 1.0, "lower_limit": 1, "manual_range": false, "marker_alpha": 1.0, "marker_edge_color": "#000000", "marker_edge_width": 1.0, "marker_fill": "#ffffff", "marker_size": 8.0, "marker_style": "o", "page": 0, "pole_alpha": 1.0, "pole_edge_color": "#000000", "pole_edge_width": 1.0, "pole_fill": "#1abd00", "pole_size": 8.0, "pole_style": "^", "rose_bottom": 0, "rose_spacing": 10, "steps": 10, "type": "faultplane", "upper_limit": 10}, [[45.0, 30.0, 45.0]]]]}"""
+    reset_project()
+    store, lyr_obj_new = gui.on_toolbutton_create_faultplane_dataset_clicked(widget=None)
+    selection = gui.layer_view.get_selection()
+    selection.select_path(0)
+    gui.add_faultplane_feature(store, 45, 30, 45, 30, "dn")
+    data = gui.on_toolbutton_copy_clicked(toolbutton=None)
+    assert data == faultplane_copy
+
+def test_copy_smallcircle():
+    """
+    Copies a smallcircle layer with one feature and asserts the string.
+    """
+    smallcircle_copy = """{"filetype": "InnStereo layer 1.0", "layers": [["0", {"arrow_color": "#d51e1e", "capstyle": "butt", "colormap": "viridis", "contour_label_size": 12, "contour_line_color": "#000000", "contour_line_style": "-", "contour_line_width": 1, "contour_method": "exponential_kamb", "contour_resolution": 40, "contour_sigma": 2, "contour_use_line_color": true, "dip_rose_spacing": 10, "draw_angelier": true, "draw_contour_fills": false, "draw_contour_labels": false, "draw_contour_lines": false, "draw_fisher_sc": false, "draw_gcircles": true, "draw_hoeppener": false, "draw_linears": true, "draw_lp_plane": false, "draw_mean_vector": false, "draw_poles": false, "fisher_conf": 95, "label": "Small-Circle Layer", "line_alpha": 1.0, "line_color": "#0000ff", "line_style": "-", "line_width": 1.0, "lower_limit": 1, "manual_range": false, "marker_alpha": 1.0, "marker_edge_color": "#000000", "marker_edge_width": 1.0, "marker_fill": "#ff7a00", "marker_size": 8.0, "marker_style": "o", "page": 0, "pole_alpha": 1.0, "pole_edge_color": "#000000", "pole_edge_width": 1.0, "pole_fill": "#1abd00", "pole_size": 8.0, "pole_style": "^", "rose_bottom": 0, "rose_spacing": 10, "steps": 10, "type": "smallcircle", "upper_limit": 10}, [[320.0, 40.0, 25.0]]]]}"""
+    reset_project()
+    store, lyr_obj_new = gui.on_toolbutton_create_small_circle_clicked(widget=None)
+    selection = gui.layer_view.get_selection()
+    selection.select_path(0)
+    gui.add_smallcircle_feature(store, 320, 40, 25)
+    data = gui.on_toolbutton_copy_clicked(toolbutton=None)
+    assert data == smallcircle_copy
+
+def test_copy_eigenvector():
+    """
+    Copies a eigenvector layer with one feature and asserts the string.
+    """
+    eigenvector_copy = """{"filetype": "InnStereo layer 1.0", "layers": [["0", {"arrow_color": "#d51e1e", "capstyle": "butt", "colormap": "viridis", "contour_label_size": 12, "contour_line_color": "#000000", "contour_line_style": "-", "contour_line_width": 1, "contour_method": "exponential_kamb", "contour_resolution": 40, "contour_sigma": 2, "contour_use_line_color": true, "dip_rose_spacing": 10, "draw_angelier": true, "draw_contour_fills": false, "draw_contour_labels": false, "draw_contour_lines": false, "draw_fisher_sc": false, "draw_gcircles": true, "draw_hoeppener": false, "draw_linears": true, "draw_lp_plane": false, "draw_mean_vector": false, "draw_poles": false, "fisher_conf": 95, "label": "Eigenvector Layer", "line_alpha": 1.0, "line_color": "#0000ff", "line_style": "-", "line_width": 1.0, "lower_limit": 1, "manual_range": false, "marker_alpha": 1.0, "marker_edge_color": "#000000", "marker_edge_width": 1.0, "marker_fill": "#ff7a00", "marker_size": 8.0, "marker_style": "o", "page": 1, "pole_alpha": 1.0, "pole_edge_color": "#000000", "pole_edge_width": 1.0, "pole_fill": "#1abd00", "pole_size": 8.0, "pole_style": "^", "rose_bottom": 0, "rose_spacing": 10, "steps": 10, "type": "eigenvector", "upper_limit": 10}, [[160.0, 80.0, 0.876]]]]}"""
+    reset_project()
+    store, lyr_obj_new = gui.add_layer_dataset("eigenvector")
+    selection = gui.layer_view.get_selection()
+    selection.select_path(0)
+    gui.add_eigenvector_feature(store, 160, 80, 0.876)
+    data = gui.on_toolbutton_copy_clicked(toolbutton=None)
+    assert data == eigenvector_copy
+
+def test_copy_group_layer():
+    """
+    Copies a group layer (folder) and asserts the string.
+    """
+    folder_copy = """{"filetype": "InnStereo layer 1.0", "layers": [["0", {"label": "Layer Group", "type": "folder"}, []]]}"""
+    reset_project()
+    gui.on_toolbutton_create_group_layer_clicked(widget=None)
+    selection = gui.layer_view.get_selection()
+    selection.select_path(0)
+    data = gui.on_toolbutton_copy_clicked(toolbutton=None)
+    assert data == folder_copy
+
+def test_plane_intersect():
+    """
+    Creates two plane layers; calculates the intersect; Asserts the project.
+    """
+    lyr_copy = """{"filetype": "InnStereo data file 1.0", "layers": [["0", {"arrow_color": "#d51e1e", "capstyle": "butt", "colormap": "viridis", "contour_label_size": 12, "contour_line_color": "#000000", "contour_line_style": "-", "contour_line_width": 1, "contour_method": "exponential_kamb", "contour_resolution": 40, "contour_sigma": 2, "contour_use_line_color": true, "dip_rose_spacing": 10, "draw_angelier": true, "draw_contour_fills": false, "draw_contour_labels": false, "draw_contour_lines": false, "draw_fisher_sc": false, "draw_gcircles": true, "draw_hoeppener": false, "draw_linears": true, "draw_lp_plane": false, "draw_mean_vector": false, "draw_poles": false, "fisher_conf": 95, "label": "Plane Layer", "line_alpha": 1.0, "line_color": "#0000ff", "line_style": "-", "line_width": 1.0, "lower_limit": 1, "manual_range": false, "marker_alpha": 1.0, "marker_edge_color": "#000000", "marker_edge_width": 1.0, "marker_fill": "#ff7a00", "marker_size": 8.0, "marker_style": "o", "page": 0, "pole_alpha": 1.0, "pole_edge_color": "#000000", "pole_edge_width": 1.0, "pole_fill": "#1abd00", "pole_size": 8.0, "pole_style": "^", "rose_bottom": 0, "rose_spacing": 10, "steps": 10, "type": "plane", "upper_limit": 10}, [[140.0, 50.0, ""]]], ["1", {"arrow_color": "#d51e1e", "capstyle": "butt", "colormap": "viridis", "contour_label_size": 12, "contour_line_color": "#000000", "contour_line_style": "-", "contour_line_width": 1, "contour_method": "exponential_kamb", "contour_resolution": 40, "contour_sigma": 2, "contour_use_line_color": true, "dip_rose_spacing": 10, "draw_angelier": true, "draw_contour_fills": false, "draw_contour_labels": false, "draw_contour_lines": false, "draw_fisher_sc": false, "draw_gcircles": true, "draw_hoeppener": false, "draw_linears": true, "draw_lp_plane": false, "draw_mean_vector": false, "draw_poles": false, "fisher_conf": 95, "label": "Plane Layer", "line_alpha": 1.0, "line_color": "#0000ff", "line_style": "-", "line_width": 1.0, "lower_limit": 1, "manual_range": false, "marker_alpha": 1.0, "marker_edge_color": "#000000", "marker_edge_width": 1.0, "marker_fill": "#ff7a00", "marker_size": 8.0, "marker_style": "o", "page": 0, "pole_alpha": 1.0, "pole_edge_color": "#000000", "pole_edge_width": 1.0, "pole_fill": "#1abd00", "pole_size": 8.0, "pole_style": "^", "rose_bottom": 0, "rose_spacing": 10, "steps": 10, "type": "plane", "upper_limit": 10}, [[270.0, 60.0, ""]]], ["2", {"arrow_color": "#d51e1e", "capstyle": "butt", "colormap": "viridis", "contour_label_size": 12, "contour_line_color": "#000000", "contour_line_style": "-", "contour_line_width": 1, "contour_method": "exponential_kamb", "contour_resolution": 40, "contour_sigma": 2, "contour_use_line_color": true, "dip_rose_spacing": 10, "draw_angelier": true, "draw_contour_fills": false, "draw_contour_labels": false, "draw_contour_lines": false, "draw_fisher_sc": false, "draw_gcircles": true, "draw_hoeppener": false, "draw_linears": true, "draw_lp_plane": false, "draw_mean_vector": false, "draw_poles": false, "fisher_conf": 95, "label": "Linear Layer", "line_alpha": 1.0, "line_color": "#0000ff", "line_style": "-", "line_width": 1.0, "lower_limit": 1, "manual_range": false, "marker_alpha": 1.0, "marker_edge_color": "#000000", "marker_edge_width": 1.0, "marker_fill": "#69b3ff", "marker_size": 8.0, "marker_style": "o", "page": 1, "pole_alpha": 1.0, "pole_edge_color": "#000000", "pole_edge_width": 1.0, "pole_fill": "#1abd00", "pole_size": 8.0, "pole_style": "^", "rose_bottom": 0, "rose_spacing": 10, "steps": 10, "type": "line", "upper_limit": 10}, [[200.07497867994334, 30.732569990472655, ""]]]], "settings": {"canvas_color": "#bfbfbf", "draw_grid": true, "draw_legend": true, "equal_area_projection": true, "grid_color": "#787878", "grid_cutoff_lat": 80, "grid_linestyle": "--", "grid_width": 0.4, "highlight": false, "major_grid_spacing": 10, "minor_grid_spacing": 2, "pixel_density": 75, "show_cross": true, "show_north": true}}"""
+    reset_project()
+    store, lyr_obj_new = gui.on_toolbutton_create_plane_dataset_clicked(widget=None)
+    gui.add_planar_feature(store, 140, 50, "")
+    store, lyr_obj_new = gui.on_toolbutton_create_plane_dataset_clicked(widget=None)
+    gui.add_planar_feature(store, 270, 60, "")
+    selection = gui.layer_view.get_selection()
+    selection.select_all()
+    gui.on_toolbutton_plane_intersect_clicked(widget=None)
+    data = gui.on_toolbutton_save_clicked(widget=None, testing=True)
+    assert data == lyr_copy
+
+def test_best_fit_plane():
+    """
+    Calculates the best-fit-plane of a set a linears. Asserts the project serialization.
+    """
+    lyr_copy = """{"filetype": "InnStereo data file 1.0", "layers": [["0", {"arrow_color": "#d51e1e", "capstyle": "butt", "colormap": "viridis", "contour_label_size": 12, "contour_line_color": "#000000", "contour_line_style": "-", "contour_line_width": 1, "contour_method": "exponential_kamb", "contour_resolution": 40, "contour_sigma": 2, "contour_use_line_color": true, "dip_rose_spacing": 10, "draw_angelier": true, "draw_contour_fills": false, "draw_contour_labels": false, "draw_contour_lines": false, "draw_fisher_sc": false, "draw_gcircles": true, "draw_hoeppener": false, "draw_linears": true, "draw_lp_plane": false, "draw_mean_vector": false, "draw_poles": false, "fisher_conf": 95, "label": "Linear Layer", "line_alpha": 1.0, "line_color": "#0000ff", "line_style": "-", "line_width": 1.0, "lower_limit": 1, "manual_range": false, "marker_alpha": 1.0, "marker_edge_color": "#000000", "marker_edge_width": 1.0, "marker_fill": "#69b3ff", "marker_size": 8.0, "marker_style": "o", "page": 1, "pole_alpha": 1.0, "pole_edge_color": "#000000", "pole_edge_width": 1.0, "pole_fill": "#1abd00", "pole_size": 8.0, "pole_style": "^", "rose_bottom": 0, "rose_spacing": 10, "steps": 10, "type": "line", "upper_limit": 10}, [[250.0, 30.0, ""], [140.0, 20.0, ""]]], ["1", {"arrow_color": "#d51e1e", "capstyle": "butt", "colormap": "viridis", "contour_label_size": 12, "contour_line_color": "#000000", "contour_line_style": "-", "contour_line_width": 1, "contour_method": "exponential_kamb", "contour_resolution": 40, "contour_sigma": 2, "contour_use_line_color": true, "dip_rose_spacing": 10, "draw_angelier": true, "draw_contour_fills": false, "draw_contour_labels": false, "draw_contour_lines": false, "draw_fisher_sc": false, "draw_gcircles": true, "draw_hoeppener": false, "draw_linears": true, "draw_lp_plane": false, "draw_mean_vector": false, "draw_poles": false, "fisher_conf": 95, "label": "Plane Layer", "line_alpha": 1.0, "line_color": "#0000ff", "line_style": "-", "line_width": 1.0, "lower_limit": 1, "manual_range": false, "marker_alpha": 1.0, "marker_edge_color": "#000000", "marker_edge_width": 1.0, "marker_fill": "#ff7a00", "marker_size": 8.0, "marker_style": "o", "page": 0, "pole_alpha": 1.0, "pole_edge_color": "#000000", "pole_edge_width": 1.0, "pole_fill": "#1abd00", "pole_size": 8.0, "pole_style": "^", "rose_bottom": 0, "rose_spacing": 10, "steps": 10, "type": "plane", "upper_limit": 10}, [[204.01898733956048, 39.72126963367138, ""]]]], "settings": {"canvas_color": "#bfbfbf", "draw_grid": true, "draw_legend": true, "equal_area_projection": true, "grid_color": "#787878", "grid_cutoff_lat": 80, "grid_linestyle": "--", "grid_width": 0.4, "highlight": false, "major_grid_spacing": 10, "minor_grid_spacing": 2, "pixel_density": 75, "show_cross": true, "show_north": true}}"""
+    reset_project()
+    store, lyr_obj_new = gui.on_toolbutton_create_line_dataset_clicked(widget=None)
+    gui.add_linear_feature(store, 250, 30, "")
+    gui.add_linear_feature(store, 140, 20, "")
+    selection = gui.layer_view.get_selection()
+    selection.select_all()
+    gui.on_toolbutton_best_plane_clicked(widget=None)
+    data = gui.on_toolbutton_save_clicked(widget=None, testing=True)
+    assert data == lyr_copy
+
+def test_mean_vector():
+    """
+    Calculates the mean vector of a set a linears. Asserts the project serialization.
+    """
+    lyr_copy = """{"filetype": "InnStereo data file 1.0", "layers": [["0", {"arrow_color": "#d51e1e", "capstyle": "butt", "colormap": "viridis", "contour_label_size": 12, "contour_line_color": "#000000", "contour_line_style": "-", "contour_line_width": 1, "contour_method": "exponential_kamb", "contour_resolution": 40, "contour_sigma": 2, "contour_use_line_color": true, "dip_rose_spacing": 10, "draw_angelier": true, "draw_contour_fills": false, "draw_contour_labels": false, "draw_contour_lines": false, "draw_fisher_sc": false, "draw_gcircles": true, "draw_hoeppener": false, "draw_linears": true, "draw_lp_plane": false, "draw_mean_vector": false, "draw_poles": false, "fisher_conf": 95, "label": "Linear Layer", "line_alpha": 1.0, "line_color": "#0000ff", "line_style": "-", "line_width": 1.0, "lower_limit": 1, "manual_range": false, "marker_alpha": 1.0, "marker_edge_color": "#000000", "marker_edge_width": 1.0, "marker_fill": "#69b3ff", "marker_size": 8.0, "marker_style": "o", "page": 1, "pole_alpha": 1.0, "pole_edge_color": "#000000", "pole_edge_width": 1.0, "pole_fill": "#1abd00", "pole_size": 8.0, "pole_style": "^", "rose_bottom": 0, "rose_spacing": 10, "steps": 10, "type": "line", "upper_limit": 10}, [[45.0, 30.0, ""], [60.0, 40.0, ""], [55.0, 20.0, ""]]], ["1", {"arrow_color": "#d51e1e", "capstyle": "butt", "colormap": "viridis", "contour_label_size": 12, "contour_line_color": "#000000", "contour_line_style": "-", "contour_line_width": 1, "contour_method": "exponential_kamb", "contour_resolution": 40, "contour_sigma": 2, "contour_use_line_color": true, "dip_rose_spacing": 10, "draw_angelier": true, "draw_contour_fills": false, "draw_contour_labels": false, "draw_contour_lines": false, "draw_fisher_sc": false, "draw_gcircles": true, "draw_hoeppener": false, "draw_linears": true, "draw_lp_plane": false, "draw_mean_vector": false, "draw_poles": false, "fisher_conf": 95, "label": "Mean Vector", "line_alpha": 1.0, "line_color": "#0000ff", "line_style": "-", "line_width": 1.0, "lower_limit": 1, "manual_range": false, "marker_alpha": 1.0, "marker_edge_color": "#000000", "marker_edge_width": 1.0, "marker_fill": "#ff7a00", "marker_size": 8.0, "marker_style": "o", "page": 1, "pole_alpha": 1.0, "pole_edge_color": "#000000", "pole_edge_width": 1.0, "pole_fill": "#1abd00", "pole_size": 8.0, "pole_style": "^", "rose_bottom": 0, "rose_spacing": 10, "steps": 10, "type": "eigenvector", "upper_limit": 10}, [[53.12603208349311, 30.142463315485486, 0.9856301083048257]]]], "settings": {"canvas_color": "#bfbfbf", "draw_grid": true, "draw_legend": true, "equal_area_projection": true, "grid_color": "#787878", "grid_cutoff_lat": 80, "grid_linestyle": "--", "grid_width": 0.4, "highlight": false, "major_grid_spacing": 10, "minor_grid_spacing": 2, "pixel_density": 75, "show_cross": true, "show_north": true}}"""
+    reset_project()
+    store, lyr_obj_new = gui.on_toolbutton_create_line_dataset_clicked(widget=None)
+    gui.add_linear_feature(store, 45, 30, "")
+    gui.add_linear_feature(store, 60, 40, "")
+    gui.add_linear_feature(store, 55, 20, "")
+    selection = gui.layer_view.get_selection()
+    selection.select_all()
+    gui.on_toolbutton_mean_vector_clicked(toolbutton=None)
+    data = gui.on_toolbutton_save_clicked(widget=None, testing=True)
+    assert data == lyr_copy

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -254,3 +254,273 @@ def test_mean_vector():
     gui.on_toolbutton_mean_vector_clicked(toolbutton=None)
     data = gui.on_toolbutton_save_clicked(widget=None, testing=True)
     assert data == lyr_copy
+
+def plane_input(inp, inp_type):
+    """
+    Tests different data inputs into a plane layer. Called from test-functions.
+    """
+    reset_project()
+    store, lyr_obj_new = gui.on_toolbutton_create_plane_dataset_clicked(widget=None)
+    gui.add_planar_feature(store, 140, 50, "")
+    data_view = lyr_obj_new.get_data_treeview()
+    if inp_type == "dir":
+        entry = data_view.renderer_dir_edited(widget=None, path=0, new_string=inp)
+    elif inp_type == "dip":
+        entry = data_view.renderer_dip_edited(widget=None, path=0, new_string=inp)
+    return entry
+
+def linear_input(inp, inp_type):
+    """
+    Tests different data inputs into a linear layer. Called from test-functions.
+    """
+    reset_project()
+    store, lyr_obj_new = gui.on_toolbutton_create_line_dataset_clicked(widget=None)
+    gui.add_linear_feature(store, 220, 40, "up")
+    data_view = lyr_obj_new.get_data_treeview()
+    if inp_type == "dir":
+        entry = data_view.renderer_dir_edited(widget=None, path=0, new_string=inp)
+    elif inp_type == "dip":
+        entry = data_view.renderer_dip_edited(widget=None, path=0, new_string=inp)
+    elif inp_type == "sense":
+        entry = data_view.renderer_sense_edited(widget=None, path=0, new_string=inp)
+    return entry
+
+def smallcircle_input(inp, inp_type):
+    """
+    Tests different data inputs into a smallcircle layer. Called from test-functions.
+    """
+    reset_project()
+    store, lyr_obj_new = gui.on_toolbutton_create_small_circle_clicked(widget=None)
+    gui.add_smallcircle_feature(store, 180, 30, 30)
+    data_view = lyr_obj_new.get_data_treeview()
+    if inp_type == "dir":
+        entry = data_view.renderer_dir_edited(widget=None, path=0, new_string=inp)
+    elif inp_type == "dip":
+        entry = data_view.renderer_dip_edited(widget=None, path=0, new_string=inp)
+    elif inp_type == "angle":
+        entry = data_view.renderer_angle_edited(widget=None, path=0, new_string=inp)
+    return entry
+
+def vector_input(inp, inp_type):
+    """
+    Tests different data inputs into a vector layer. Called from test-functions.
+    """
+    reset_project()
+    store, lyr_obj_new = gui.add_layer_dataset("eigenvector")
+    gui.add_eigenvector_feature(store, 45, 10, 0.1)
+    data_view = lyr_obj_new.get_data_treeview()
+    if inp_type == "dir":
+        entry = data_view.renderer_dir_edited(widget=None, path=0, new_string=inp)
+    elif inp_type == "dip":
+        entry = data_view.renderer_dip_edited(widget=None, path=0, new_string=inp)
+    elif inp_type == "magn":
+        entry = data_view.renderer_value_edited(widget=None, path=0, new_string=inp)
+    return entry
+
+def faultplane_input(inp, inp_type):
+    """
+    Tests different data inputs for faultplane layers. Called from test-functions.
+    """
+    reset_project()
+    store, lyr_obj_new = gui.on_toolbutton_create_faultplane_dataset_clicked(widget=None)
+    gui.add_faultplane_feature(store, 115, 12, 115, 12, "up")
+    data_view = lyr_obj_new.get_data_treeview()
+    if inp_type == "dir":
+        entry = data_view.renderer_dir_edited(widget=None, path=0, new_string=inp)
+    elif inp_type == "dip":
+        entry = data_view.renderer_dip_edited(widget=None, path=0, new_string=inp)
+    elif inp_type == "ldir":
+        entry = data_view.renderer_ldir_edited(widget=None, path=0, new_string=inp)
+    elif inp_type == "ldip":
+        entry = data_view.renderer_ldip_edited(widget=None, path=0, new_string=inp)
+    elif inp_type == "sense":
+        entry = data_view.renderer_sense_edited(widget=None, path=0, new_string=inp)
+    return entry
+
+dir_cases = {
+    "aword": None,
+    "": 0,
+    "0": 0,
+    "360": 360,
+    "120.075": 120.075,
+    "120,075": 120.075,
+    "400": 40,
+    "-20": 340,
+}
+
+dip_cases = {
+    "aword": None,
+    "": 0,
+    "0": 0,
+    "90": 90,
+    "-10": None,
+    "110": None,
+    "56.045": 56.045,
+    "56,045": 56.045,
+}
+
+sense_cases ={
+    "aword": None,
+    "": "",
+    "uk": "uk",
+    "up": "up",
+    "dn": "dn",
+    "sin": "sin",
+    "dex": "dex",
+    "0": "uk",
+    "1": "up",
+    "2": "dn",
+    "3": "dex",
+    "4": "sin",
+    "5": None,
+}
+
+sc_cases = {
+    "aword": None,
+    "": 0,
+    "0": 0,
+    "360": 360,
+    "120.075": 120.075,
+    "120,075": 120.075,
+    "400": None,
+    "-20": None,
+}
+
+magnitude_cases = {
+    "aword": None,
+    "": 0,
+    "0": 0,
+    "1": 1,
+    "0.005": 0.005,
+    "-2": None,
+    "2": None,
+}
+
+def test_plane_direction_input():
+    """
+    Tests different inputs for the plane dip-direction.
+    """
+    for case in dir_cases:
+        value = plane_input(case, "dir")
+        assert value == dir_cases[case]
+
+def test_plane_dip_input():
+    """
+    Tests different inputs for the plane dip.
+    """
+    for case in dip_cases:
+        value = plane_input(case, "dip")
+        assert value == dip_cases[case]
+
+def test_linear_direction_input():
+    """
+    Test different inputs for the linear dip-direction.
+    """
+    for case in dir_cases:
+        value = linear_input(case, "dir")
+        assert value == dir_cases[case]
+
+def test_linear_dip_input():
+    """
+    Test different inputs for the linear dip.
+    """
+    for case in dip_cases:
+        value = linear_input(case, "dip")
+        assert value == dip_cases[case]
+
+def test_linear_sense_input():
+    """
+    Tests different inputs for the linear sense.
+    """
+    for case in sense_cases:
+        value = linear_input(case, "sense")
+        assert value == sense_cases[case]
+
+def test_smallcircle_direction_input():
+    """
+    Test different inputs for the smallcircle dip-direction.
+    """
+    for case in dir_cases:
+        value = smallcircle_input(case, "dir")
+        assert value == dir_cases[case]
+
+def test_smallcircle_dip_input():
+    """
+    Test different inputs for the smallcircle dip.
+    """
+    for case in dip_cases:
+        value = smallcircle_input(case, "dip")
+        assert value == dip_cases[case]
+
+def test_smallcircle_angle_input():
+    """
+    Test different inputs for the smallcircle opening angle.
+    """
+    for case in sc_cases:
+        value = smallcircle_input(case, "angle")
+        assert value == sc_cases[case]
+
+def test_vector_direction_input():
+    """
+    Test different inputs for the vector dip-direction.
+    """
+    for case in dir_cases:
+        value = vector_input(case, "dir")
+        assert value == dir_cases[case]
+
+def test_vector_dip_input():
+    """
+    Test different inputs for the vector dip.
+    """
+    for case in dip_cases:
+        value = vector_input(case, "dip")
+        assert value == dip_cases[case]
+
+def test_vector_magnitude_input():
+    """
+    Test different inputs for the vector magnitude.
+    """
+    for case in magnitude_cases:
+        value = vector_input(case, "magn")
+        assert value == magnitude_cases[case]
+
+def test_fp_plane_direction_input():
+    """
+    Test different inputs for the faultplane plane dip-direction.
+    """
+    for case in dir_cases:
+        value = faultplane_input(case, "dir")
+        assert value == dir_cases[case]
+
+def test_fp_plane_dip_input():
+    """
+    Test different inputs for the faultplane plane dip.
+    """
+    for case in dip_cases:
+        value = faultplane_input(case, "dip")
+        assert value == dip_cases[case]
+
+def test_fp_linear_direction_input():
+    """
+    Test different inputs for the faultplane linear dip-direction.
+    """
+    for case in dir_cases:
+        value = faultplane_input(case, "dir")
+        assert value == dir_cases[case]
+
+def test_fp_linear_dip_input():
+    """
+    Test different inputs for the faultplane linear dip.
+    """
+    for case in dip_cases:
+        value = faultplane_input(case, "dip")
+        assert value == dip_cases[case]
+
+def test_fp_sense_input():
+    """
+    Tests different inputs for the linear sense.
+    """
+    for case in sense_cases:
+        value = faultplane_input(case, "sense")
+        assert value == sense_cases[case]
+


### PR DESCRIPTION
This PR includes some test for the user interface. The random dictionary order of Python3 was getting in the way of reproducible tests. Instead of dealing with that problem I just made the dictionaries ordered. Probably should have no performance impact.

The program now also validates the inputs for all layers. This includes entering numbers instead of strings for the shear sense. Tests for different inputs are also included.