### PR TITLE
GSettings schema and dialog

### DIFF
--- a/data/org.gtk.innstereo.gschema.xml
+++ b/data/org.gtk.innstereo.gschema.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schemalist>
+  <schema id="org.gtk.innstereo" path="/org/gtk/innstereo/">
+    <key type="b" name="draw-grid">
+      <default>true</default>
+      <summary>Draw stereonet grid</summary>
+      <description>This sets whether the stereonet-grid should be drawn.</description>
+    </key>
+    <key type="b" name="stereonet-projection">
+      <default>true</default>
+      <summary>Equal area or equal angle projection</summary>
+      <description>True = equal area. False = equal angle.</description>
+    </key>
+    <key type="b" name="show-legend">
+      <default>true</default>
+      <summary>Display a legend by default</summary>
+      <description>True means that a legend will be drawn by default.</description>
+    </key>
+    <key type="b" name="center-cross">
+      <default>true</default>
+      <summary>Center stereonet cross</summary>
+      <description>When True a cross is displayed at the center of the stereonet.</description>
+    </key>
+  </schema>
+</schemalist>
+

--- a/innstereo/gui_layout.glade
+++ b/innstereo/gui_layout.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 
+<!-- Generated with glade 3.19.0 
 
 InnStereo - An open source stereographic projection program used for geology
 Copyright (C) 
@@ -3217,30 +3217,6 @@ customizable grid.</property>
                     <child>
                       <placeholder/>
                     </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
                   </object>
                   <packing>
                     <property name="position">3</property>
@@ -4615,6 +4591,20 @@ customizable grid.</property>
                 <property name="homogeneous">True</property>
               </packing>
             </child>
+            <child>
+              <object class="GtkToolButton" id="toolbutton_settings">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Settings</property>
+                <property name="use_underline">True</property>
+                <property name="stock_id">gtk-justify-fill</property>
+                <signal name="clicked" handler="on_toolbutton_settings_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="homogeneous">True</property>
+              </packing>
+            </child>
             <style>
               <class name="Gtk.STYLE_CLASS_PRIMARY_TOOLBAR"/>
             </style>
@@ -5033,6 +5023,282 @@ customizable grid.</property>
             <property name="expand">True</property>
             <property name="fill">True</property>
             <property name="position">2</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
+  <object class="GtkApplicationWindow" id="settings_window">
+    <property name="can_focus">False</property>
+    <property name="title" translatable="yes">InnStereo Settings</property>
+    <property name="window_position">center-on-parent</property>
+    <property name="default_width">600</property>
+    <property name="default_height">250</property>
+    <signal name="destroy" handler="on_settings_window_destroy" swapped="no"/>
+    <child>
+      <object class="GtkBox" id="box10">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <child>
+          <object class="GtkScrolledWindow" id="scrolledwindow1">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="shadow_type">in</property>
+            <child>
+              <object class="GtkViewport" id="viewport1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <child>
+                  <object class="GtkGrid" id="grid1">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <child>
+                      <object class="GtkLabel" id="label75">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="margin_left">5</property>
+                        <property name="margin_right">5</property>
+                        <property name="margin_top">5</property>
+                        <property name="margin_bottom">10</property>
+                        <property name="label" translatable="yes">&lt;b&gt;Stereonet Projection&lt;/b&gt;</property>
+                        <property name="use_markup">True</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">0</property>
+                        <property name="width">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkRadioButton" id="radiobutton_def_area">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="halign">end</property>
+                        <property name="valign">start</property>
+                        <property name="margin_left">30</property>
+                        <property name="margin_right">5</property>
+                        <property name="margin_top">5</property>
+                        <property name="margin_bottom">5</property>
+                        <property name="xalign">0</property>
+                        <property name="active">True</property>
+                        <property name="draw_indicator">True</property>
+                        <signal name="toggled" handler="on_radiobutton_def_area_toggled" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkRadioButton" id="radiobutton_def_angle">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="halign">end</property>
+                        <property name="valign">start</property>
+                        <property name="margin_left">30</property>
+                        <property name="margin_right">5</property>
+                        <property name="margin_top">5</property>
+                        <property name="margin_bottom">5</property>
+                        <property name="xalign">0</property>
+                        <property name="active">True</property>
+                        <property name="draw_indicator">True</property>
+                        <property name="group">radiobutton_def_area</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label76">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="margin_left">5</property>
+                        <property name="margin_right">5</property>
+                        <property name="margin_top">5</property>
+                        <property name="margin_bottom">5</property>
+                        <property name="label" translatable="yes">&lt;b&gt;Equal Area&lt;/b&gt;
+Uses a Lambert Azimuthal Equal-Area Projection or Schmidt Net.</property>
+                        <property name="use_markup">True</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label77">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="margin_left">5</property>
+                        <property name="margin_right">5</property>
+                        <property name="margin_top">5</property>
+                        <property name="margin_bottom">5</property>
+                        <property name="label" translatable="yes">&lt;b&gt;Equal Angle&lt;/b&gt;
+Uses a Stereographic Projection or Wulff Net.</property>
+                        <property name="use_markup">True</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label78">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="margin_left">5</property>
+                        <property name="margin_right">5</property>
+                        <property name="margin_top">10</property>
+                        <property name="margin_bottom">10</property>
+                        <property name="label" translatable="yes">&lt;b&gt;Stereonet Grid&lt;/b&gt;</property>
+                        <property name="use_markup">True</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">3</property>
+                        <property name="width">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkSwitch" id="switch_def_grid">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="halign">end</property>
+                        <property name="valign">start</property>
+                        <property name="margin_left">30</property>
+                        <property name="margin_right">5</property>
+                        <property name="margin_top">5</property>
+                        <property name="margin_bottom">5</property>
+                        <signal name="state-set" handler="on_switch_def_grid_state_set" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">4</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label79">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="margin_left">5</property>
+                        <property name="margin_right">5</property>
+                        <property name="margin_top">5</property>
+                        <property name="margin_bottom">5</property>
+                        <property name="label" translatable="yes">&lt;b&gt;Show Grid&lt;/b&gt;
+Will display a grid in the background of the stereonet.</property>
+                        <property name="use_markup">True</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">4</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkSwitch" id="switch_def_cross">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="halign">end</property>
+                        <property name="valign">start</property>
+                        <property name="margin_left">30</property>
+                        <property name="margin_right">5</property>
+                        <property name="margin_top">5</property>
+                        <property name="margin_bottom">5</property>
+                        <signal name="state-set" handler="on_switch_def_cross_state_set" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">5</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label80">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="margin_left">5</property>
+                        <property name="margin_right">5</property>
+                        <property name="margin_top">5</property>
+                        <property name="margin_bottom">5</property>
+                        <property name="label" translatable="yes">&lt;b&gt;Center Cross&lt;/b&gt;
+A cross will be shown in the center of the stereonet.</property>
+                        <property name="use_markup">True</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">5</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label81">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="margin_left">5</property>
+                        <property name="margin_right">5</property>
+                        <property name="margin_top">10</property>
+                        <property name="margin_bottom">10</property>
+                        <property name="label" translatable="yes">&lt;b&gt;Legend&lt;/b&gt;</property>
+                        <property name="use_markup">True</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">6</property>
+                        <property name="width">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkSwitch" id="switch_def_legend">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="halign">end</property>
+                        <property name="valign">start</property>
+                        <property name="margin_left">30</property>
+                        <property name="margin_right">5</property>
+                        <property name="margin_top">5</property>
+                        <property name="margin_bottom">5</property>
+                        <signal name="state-set" handler="on_switch_def_legend_state_set" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">7</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label82">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="margin_left">5</property>
+                        <property name="margin_right">5</property>
+                        <property name="margin_top">5</property>
+                        <property name="margin_bottom">5</property>
+                        <property name="label" translatable="yes">&lt;b&gt;Show Legend&lt;/b&gt;
+Will generate an automatic legend on the project canvas.</property>
+                        <property name="use_markup">True</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">7</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
           </packing>
         </child>
       </object>

--- a/innstereo/main_ui.py
+++ b/innstereo/main_ui.py
@@ -40,6 +40,7 @@ from .polar_axes import NorthPolarAxes
 from .file_parser import FileParseDialog
 from .rotation_dialog import RotationDialog
 from .viridis import viridis
+from .settings import AppSettings
 
 from .i18n import i18n
 
@@ -553,6 +554,15 @@ class MainWindow(object):
         state = self.settings.get_night_mode()
         Gtk.Settings.get_default().set_property("gtk-application-prefer-dark-theme", state)
         self.main_window.show_all()
+
+    def on_toolbutton_settings_clicked(self, toolbutton):
+        """
+        Opens the window where the GSettings can be set for Innstereo.
+
+        An instance of the window is created and then displayed.
+        """
+        set_win = AppSettings(self.main_window)
+        set_win.run()
 
     def on_toolbutton_eigenvector_clicked(self, widget):
         # pylint: disable=unused-argument

--- a/innstereo/plot_control.py
+++ b/innstereo/plot_control.py
@@ -12,7 +12,7 @@ of the stereonet, and will return the correct one for either the Schmidt- or
 Wulff-Net.
 """
 
-from gi.repository import Gtk, Gdk
+from gi.repository import Gtk, Gdk, Gio
 from matplotlib.figure import Figure
 from matplotlib.gridspec import GridSpec
 import mplstereonet
@@ -58,6 +58,17 @@ class PlotSettings(object):
                       }.items()))
         self.night_mode = False
         self.fig = Figure(dpi=self.props["pixel_density"])
+        self.g_settings = Gio.Settings.new("org.gtk.innstereo")
+        self.get_defaults()
+
+    def get_defaults(self):
+        """
+        Gets the defaults from the Gio.Settings.
+        """
+        self.props["draw_legend"] = self.g_settings.get_boolean("show-legend")
+        self.props["draw_grid"] = self.g_settings.get_boolean("draw-grid")
+        self.props["equal_area_projection"] = self.g_settings.get_boolean("stereonet-projection")
+        self.props["show_cross"] = self.g_settings.get_boolean("center-cross")
 
     def get_fig(self):
         """

--- a/innstereo/settings.py
+++ b/innstereo/settings.py
@@ -1,0 +1,90 @@
+#!/usr/bin/python3
+
+"""
+This module contains the AppSettings class that handles the signals of the
+default-application-settings window.
+"""
+
+from gi.repository import Gtk, Gdk, Gio
+from collections import OrderedDict
+import os
+
+
+class AppSettings(object):
+
+    """
+    Handles the signals of the default-application-settings window.
+    """
+
+    def __init__(self, main_window):
+        """
+        Initalizes the GUI. Connects to Gio.Settings. Loads the defaults.
+        """
+        self.builder = Gtk.Builder()
+        script_dir = os.path.dirname(__file__)
+        rel_path = "gui_layout.glade"
+        abs_path = os.path.join(script_dir, rel_path)
+        self.builder.add_objects_from_file(abs_path,
+            ("settings_window", ""))
+        self.set_win = self.builder.get_object("settings_window")
+        self.switch_def_legend = self.builder.get_object("switch_def_legend")
+        self.switch_def_grid = self.builder.get_object("switch_def_grid")
+        self.switch_def_cross = self.builder.get_object("switch_def_cross")
+        self.radiobutton_def_area = self.builder.get_object("radiobutton_def_area")
+        self.radiobutton_def_angle = self.builder.get_object("radiobutton_def_angle")
+        self.set_win.set_transient_for(main_window)
+        self.builder.connect_signals(self)
+
+        self.g_settings = Gio.Settings.new("org.gtk.innstereo")
+        self.get_defaults()
+
+    def get_defaults(self):
+        """
+        Loads the defaults from the Gio.Settings and applies them to the GUI.
+        """
+        self.switch_def_legend.set_active(self.g_settings.get_boolean("show-legend"))
+        self.switch_def_grid.set_active(self.g_settings.get_boolean("draw-grid"))
+        self.switch_def_cross.set_active(self.g_settings.get_boolean("center-cross"))
+        projection = self.g_settings.get_boolean("stereonet-projection")
+        if projection == True:
+            self.radiobutton_def_area.set_active(True)
+        else:
+            self.radiobutton_def_angle.set_active(True)
+
+    def on_settings_window_destroy(self, widget):
+        """
+        Hides the window.
+        """
+        self.set_win.hide()
+
+    def run(self):
+        """
+        Shows the window.
+        """
+        self.set_win.show()
+
+    def on_switch_def_legend_state_set(self, switch, state):
+        """
+        Sets a new state for whether the legend should be drawn by default.
+        """
+        self.g_settings.set_boolean("show-legend", state)
+
+    def on_switch_def_grid_state_set(self, switch, state):
+        """
+        Sets a new state for whether the grid should be drawn by default.
+        """
+        self.g_settings.set_boolean("draw-grid", state)
+
+    def on_switch_def_cross_state_set(self, switch, state):
+        """
+        Sets a new state for whether the cross should be drawn by default.
+        """
+        self.g_settings.set_boolean("center-cross", state)
+
+    def on_radiobutton_def_area_toggled(self, radiobutton):
+        """
+        Sets a new state for which projection should be used by default.
+        """
+        state = radiobutton.get_active()
+        self.g_settings.set_boolean("stereonet-projection", state)
+                


### PR DESCRIPTION
This PR includes the first settings included in the GSettings schema. The default settings can be customized within a dialog that is currently accessible through a button in the toolbar. The settings need to be copied into the correct folder and compiled before InnStereo can be started:

```
cp gschema.xml /usr/share/glib-2.0/schemas/
glib-compile-schemas /usr/share/glib-2.0/schemas/
```

See: http://www.micahcarrick.com/gsettings-python-gnome-3.html