### PR TITLE
use gi.require_version to resolve a PyGIWarning

### DIFF
--- a/innstereo/main_ui.py
+++ b/innstereo/main_ui.py
@@ -8,6 +8,10 @@ modules and clases are controlled from this class. The startup-function creates
 the first instance of the GUI when the program starts.
 """
 
+import gi
+
+gi.require_version('Gtk', '3.0')
+
 from gi.repository import Gtk, Gdk, GdkPixbuf
 from matplotlib.backends.backend_gtk3cairo import (FigureCanvasGTK3Cairo
                                                    as FigureCanvas)


### PR DESCRIPTION
Hi,
if it's not specified the gtk version for gi then a blocking PyGIWarning is issued.
This patch invokes gi.require_version to fix this issue.
Verified on Mageia 6 (development branch).
Cheers