### PR TITLE
fixed scripts entry

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         "Topic :: Scientific/Engineering",
         ],
     packages = ["innstereo"],
-    scripts = [pjoin("bin","innstereo")],
+    scripts = [pjoin("bin","innstereo.py")],
     install_requires = ["numpy >= 1.6.0",
                         "scipy >= 0.13",
                         "matplotlib >= 1.4.0",


### PR DESCRIPTION
Hi,
scripts declared as bin/innstereo was not working locally (GNU/Linux, Mageia 5).
I managed to fix this bug buy specifing the name with the extension.

Regards