### PR TITLE
Merge: Make i18n work on win32 - Some updates to build-files

### DIFF
--- a/EXTRAS
+++ b/EXTRAS
@@ -1,8 +1,12 @@
-# create the pot file from the source code
-xgettext --from-code=UTF-8 --keyword=translatable --keyword=_ --sort-output innstereo/*.{py,glade} -o po/innstereo.pot
+# Create the pot file from the source code
+    xgettext --from-code=UTF-8 --keyword=translatable --keyword=_ --sort-output innstereo/*.{py,glade} -o po/innstereo.pot
 
-# to start a new localization
-msginit --locale=$LANG --input=innstereo.pot
+# To start a new localization
+    msginit --locale=$LANG --input=innstereo.pot
 
-# to compile the po thus build mo
-msgfmt -o po/it_IT.UTF-8.mo po/it_IT.UTF-8.po
+# To compile the po thus build mo
+    msgfmt -o po/it_IT.UTF-8.mo po/it_IT.UTF-8.po
+
+# The mo files have to go into the directory po/$LANG/LC_MESSAGES/innstereo.mo
+# e.g. Italian: po/it/LC_MESSAGES/innstereo.mo
+# e.g. French: po/fr/LC_MESSAGES/innstereo.mo

--- a/innstereo/dialog_windows.py
+++ b/innstereo/dialog_windows.py
@@ -10,8 +10,11 @@ and FileChooserParse-class.
 
 from gi.repository import Gtk
 import matplotlib.colors as colors
-import os
-from .i18n import i18n
+import os, sys
+from .i18n import i18n, translate_gui
+
+
+_ = i18n().language().gettext
 
 
 class AboutDialog(object):
@@ -41,6 +44,8 @@ class AboutDialog(object):
         self.ab = self.builder.get_object("aboutdialog")
         self.ab.set_transient_for(main_window)
         self.builder.connect_signals(self)
+        if sys.platform == "win32":
+            translate_gui(self.builder)
 
     def run(self):
         """
@@ -139,6 +144,8 @@ class StereonetProperties(object):
         self.switch_highlight.set_active(self.settings.get_highlight())
         self.switch_night_mode.set_active(self.settings.get_night_mode())
         self.builder.connect_signals(self)
+        if sys.platform == "win32":
+            translate_gui(self.builder)
 
     def on_spinbutton_pixel_density_value_changed(self, spinbutton):
         # pylint: disable=unused-argument
@@ -324,6 +331,8 @@ class FileChooserParse(object):
         self.dialog.add_filter(self.filefilters)
         self.run_file_parser = run_file_parser
         self.builder.connect_signals(self)
+        if sys.platform == "win32":
+            translate_gui(self.builder)
 
     def run(self):
         """
@@ -405,6 +414,8 @@ class FileChooserExport(object):
         self.dialog = self.builder.get_object("filechooserdialog_export")
         self.dialog.set_transient_for(main_window)
         self.builder.connect_signals(self)
+        if sys.platform == "win32":
+            translate_gui(self.builder)
 
     def run(self):
         """
@@ -503,6 +514,8 @@ class OverwriteDialog(object):
         self.dialog = self.builder.get_object("dialog_overwrite")
         self.dialog.set_transient_for(export_dialog)
         self.builder.connect_signals(self)
+        if sys.platform == "win32":
+            translate_gui(self.builder)
 
     def run(self):
         """
@@ -556,6 +569,8 @@ class FileChooserSave(object):
         self.dialog = self.builder.get_object("filechooserdialog_save")
         self.dialog.set_transient_for(main_window)
         self.builder.connect_signals(self)
+        if sys.platform == "win32":
+            translate_gui(self.builder)
 
     def run(self):
         """
@@ -661,6 +676,8 @@ class FileChooserOpen(object):
         self.dialog.add_filter(filter_all)
         self.open_project = open_project
         self.builder.connect_signals(self)
+        if sys.platform == "win32":
+            translate_gui(self.builder)
 
     def run(self):
         """

--- a/innstereo/gui_layout.glade
+++ b/innstereo/gui_layout.glade
@@ -50,6 +50,7 @@ Thomas Kluyver
 Andreas Kositz
 Hugo Ortner
 Martin Reiser
+Christoph Reiter
     </property>
     <property name="logo">logo_about.svg</property>
     <property name="license_type">gpl-2-0</property>

--- a/innstereo/i18n.py
+++ b/innstereo/i18n.py
@@ -21,7 +21,6 @@
 #    You should have received a copy of the GNU General Public License         #
 #    along with InnStereo.  If not, see <http://www.gnu.org/licenses/>.        #
 #==============================================================================#
-# -*- coding: utf-8 -*-
 
 import os, sys
 import locale
@@ -32,8 +31,8 @@ class i18n:
   language = None
   
   def __init__(self):
-    #  The translation files will be under
-    #  @locale_dir@/@LANGUAGE@/LC_MESSAGES/@app_name@.mo
+    # The translation files will be under
+    # @locale_dir@/@LANGUAGE@/LC_MESSAGES/@app_name@.mo
     self.app_name = "innstereo"
 
     #app_dir = os.getcwd()
@@ -43,7 +42,6 @@ class i18n:
 
     # Now we need to choose the language. We will provide a list, and gettext
     # will use the first translation available in the list
-    #
     default_languages = os.environ.get('LANG', '').split(':')
     default_languages += ['en_US']
 
@@ -52,7 +50,7 @@ class i18n:
         languages = [lc]
 
     # Concat all languages (env + default locale),
-    #  and here we have the languages and location of the translations
+    # and here we have the languages and location of the translations
     languages += default_languages
     mo_location = locale_dir
 
@@ -63,7 +61,8 @@ class i18n:
 
     gettext.find(self.app_name, mo_location)
 
-    #This try-except is needed for platforms that have no access to locale.bindtextdomain()
+    # This try-except is needed for platforms that have no
+    # access to locale.bindtextdomain()
     try:
         locale.bindtextdomain(self.app_name, locale_dir)
     except:

--- a/innstereo/i18n.py
+++ b/innstereo/i18n.py
@@ -25,60 +25,92 @@
 import os, sys
 import locale
 import gettext
+from os.path import join, abspath
+from gi.repository import Gtk
 
 class i18n:
-  app_name = ""
-  language = None
+    app_name = ""
+    language = None
+
+    def __init__(self):
+        # The translation files will be under
+        # @locale_dir@/@LANGUAGE@/LC_MESSAGES/@app_name@.mo
+        self.app_name = "innstereo"
+        app_dir = abspath(os.path.dirname(__file__))
+        print("app dir:", app_dir)
+
+        # Locale are stored in innstereo/locale
+        # .mo files will then be located in innstereo/locale/LANGUAGECODE/LC_MESSAGES/
+        locale_dir = abspath(join(app_dir, "locale"))
+        print("locale dir", locale_dir)
+
+        if sys.platform == "win32":
+            # Set $LANG on MS Windows for gettext
+            if os.getenv('LANG') is None:
+                lang, enc = locale.getdefaultlocale() #lang is POSIX e.g. de_DE
+                print(lang, enc)
+                os.environ['LANG'] = lang
+                languages = [lang]
+
+            # Set LOCALE_DIR for MS Windows
+            import ctypes
+            LIB_INTL = abspath(join(app_dir, "../gnome/libintl-8.dll"))
+            print("LIB_INTL", LIB_INTL)
+            libintl = ctypes.cdll.LoadLibrary(LIB_INTL)
+            lc = locale.setlocale(locale.LC_ALL, "")
+            locale_dir_g = abspath(join(app_dir, "locale"))
+            print(lc) # Returns local. On W e.g. German_Germany.1252
+            libintl.bindtextdomain(self.app_name, locale_dir_g)
+            libintl.bind_textdomain_codeset(self.app_name, "UTF-8")
+        else:
+            kwargs = {}
+            if sys.version < '3':
+                kwargs['unicode'] = 1
+            gettext.install(True, localedir=None, **kwargs)
+
+            gettext.find(self.app_name, locale_dir)
+            locale.bindtextdomain(self.app_name, locale_dir)
+
+        # Now we need to choose the language. We will provide a list, and gettext
+        # will use the first translation available in the list
+        default_languages = os.environ.get('LANG', '').split(':')
+        default_languages += ['en_US']
+
+        lc, encoding = locale.getdefaultlocale()
+        if lc:
+            languages = [lc]
+
+        # Concat all languages (env + default locale),
+        # and here we have the languages and location of the translations
+        languages += default_languages
+
+        gettext.bindtextdomain (self.app_name, locale_dir)
+        gettext.textdomain (self.app_name)
+
+        self._language = gettext.translation(self.app_name, locale_dir,
+                                             languages=languages, fallback=True)
+
+    def language(self):
+        return self._language
+
+    def get_ts_domain(self):
+        return self.app_name
+
+
+_ = i18n().language().gettext
   
-  def __init__(self):
-    # The translation files will be under
-    # @locale_dir@/@LANGUAGE@/LC_MESSAGES/@app_name@.mo
-    self.app_name = "innstereo"
-
-    #app_dir = os.getcwd()
-    app_dir = os.path.dirname(os.path.abspath(os.path.dirname(__file__)))
-    locale_dir = os.path.join(app_dir, 'po') 
-    # .mo files will then be located in APP_Dir/po/LANGUAGECODE/LC_MESSAGES/
-
-    # Now we need to choose the language. We will provide a list, and gettext
-    # will use the first translation available in the list
-    default_languages = os.environ.get('LANG', '').split(':')
-    default_languages += ['en_US']
-
-    lc, encoding = locale.getdefaultlocale()
-    if lc:
-        languages = [lc]
-
-    # Concat all languages (env + default locale),
-    # and here we have the languages and location of the translations
-    languages += default_languages
-    mo_location = locale_dir
-
-    kwargs = {}
-    if sys.version < '3':
-        kwargs['unicode'] = 1
-    gettext.install(True,localedir=None,**kwargs)
-
-    gettext.find(self.app_name, mo_location)
-
-    # This try-except is needed for platforms that have no
-    # access to locale.bindtextdomain()
-    try:
-        locale.bindtextdomain(self.app_name, locale_dir)
-    except:
-        pass
-
-    gettext.bindtextdomain (self.app_name, locale_dir)
-
-    gettext.textdomain (self.app_name)
-
-    #gettext.bind_textdomain_codeset(self.app_name, "UTF-8")
-
-    self._language = gettext.translation(self.app_name, mo_location, languages = languages, fallback = True)
-
-  def language(self):
-    return self._language
-
-  def get_ts_domain(self):
-    return self.app_name
-  
+def translate_gui(builder):
+    for obj in builder.get_objects():
+        print(obj)
+        if (not isinstance(obj, Gtk.SeparatorMenuItem)) and hasattr(obj, "get_label"):
+            label = obj.get_label()
+            if label is not None:
+                obj.set_label(_(label))
+        elif hasattr(obj, "get_title"):
+            title = obj.get_title()
+            if title is not None:
+                obj.set_title(_(title))
+        if hasattr(obj, "get_tooltip_text"):
+            text = obj.get_tooltip_text()
+            if text is not None:
+                obj.set_tooltip_text(_(text))

--- a/innstereo/layer_properties.py
+++ b/innstereo/layer_properties.py
@@ -10,9 +10,9 @@ and FileChooserParse-class.
 
 from gi.repository import Gtk
 import matplotlib.colors as colors
-import os
+import os, sys
 import numpy as np
-from .i18n import i18n
+from .i18n import i18n, translate_gui
 
 
 class LayerProperties(object):
@@ -79,6 +79,8 @@ class LayerProperties(object):
         self.hide_gui_elements()
         self.set_contour_range_label()
         self.builder.connect_signals(self)
+        if sys.platform == "win32":
+            translate_gui(self.builder)
 
     def load_circle_properties(self):
         """
@@ -249,6 +251,7 @@ class LayerProperties(object):
                         self.builder.get_object("adjustment_steps")
         self.label_contour_steps = \
                         self.builder.get_object("label_contour_steps")
+        self.label_contour_steps.set_text("")
         self.switch_draw_contour_fills.set_active(
                                 self.layer.get_draw_contour_fills())
         self.switch_contour_lines.set_active(

--- a/innstereo/layer_view.py
+++ b/innstereo/layer_view.py
@@ -9,7 +9,9 @@ class inherits from Gtk.TreeView and requires a Gtk.TreeStore to initialize.
 """
 
 from gi.repository import Gtk, Gdk
+from .i18n import i18n
 
+_ = i18n().language().gettext
 
 class LayerTreeView(Gtk.TreeView):
 

--- a/innstereo/main_ui.py
+++ b/innstereo/main_ui.py
@@ -22,7 +22,7 @@ import mplstereonet
 import numpy as np
 import scipy.spatial as spatial
 import webbrowser
-import os
+import os, sys
 import csv
 from matplotlib.lines import Line2D
 import json
@@ -46,7 +46,7 @@ from .rotation_dialog import RotationDialog
 from .viridis import viridis
 from .settings import AppSettings
 
-from .i18n import i18n
+from .i18n import i18n, translate_gui
 
 _ = i18n().language().gettext
 
@@ -132,6 +132,8 @@ class MainWindow(object):
         self.canvas.mpl_connect('button_press_event',
             self.mpl_canvas_clicked)
         self.redraw_plot()
+        if sys.platform == "win32":
+            translate_gui(builder)
         self.main_window.show_all()
 
     def set_up_fisher_menu(self):

--- a/innstereo/rotation_dialog.py
+++ b/innstereo/rotation_dialog.py
@@ -14,7 +14,8 @@ from matplotlib.backends.backend_gtk3cairo import (FigureCanvasGTK3Cairo
                                                    as FigureCanvas)
 import numpy as np
 import mplstereonet
-import os
+import os, sys
+from .i18n import i18n, translate_gui
 
 
 class RotationDialog(object):
@@ -37,6 +38,7 @@ class RotationDialog(object):
         rotated data.
         """
         self.builder = Gtk.Builder()
+        self.builder.set_translation_domain(i18n().get_ts_domain())
         script_dir = os.path.dirname(__file__)
         rel_path = "gui_layout.glade"
         abs_path = os.path.join(script_dir, rel_path)
@@ -80,6 +82,8 @@ class RotationDialog(object):
         self.redraw_plot()
         self.dialog.show_all()
         self.builder.connect_signals(self)
+        if sys.platform == "win32":
+            translate_gui(self.builder)
 
     def run(self):
         """

--- a/innstereo/settings.py
+++ b/innstereo/settings.py
@@ -7,8 +7,8 @@ default-application-settings window.
 
 from gi.repository import Gtk, Gdk, Gio, GLib
 from collections import OrderedDict
-import os
-from .i18n import i18n
+import os, sys
+from .i18n import i18n, translate_gui
 
 
 class AppSettings(object):
@@ -43,6 +43,8 @@ class AppSettings(object):
 
         self.g_settings = Gio.Settings.new("org.gtk.innstereo")
         self.get_defaults()
+        if sys.platform == "win32":
+            translate_gui(self.builder)
 
     def get_defaults(self):
         """

--- a/known_issues.rst
+++ b/known_issues.rst
@@ -13,7 +13,7 @@ Some issues are discussed at the projects issue tracker: https://github.com/tobi
 Possible Additions
 ------------------
 
- - Print Dialog
+ - Print Dialog (proably not in the scope of this program)
  - Paleostress View
     - Fluctuation histogram
     - PT-Axis
@@ -22,3 +22,4 @@ Possible Additions
  - Histograms (as opposed to Rose-Histograms)
  - Find axial planes
  - Find conjugated planes (Riedel and similar planes)
+ - Add layers from databases (SQLite, Postgres)

--- a/make_win.py
+++ b/make_win.py
@@ -1,0 +1,78 @@
+import os, sys
+from subprocess import call
+import nsist
+
+gsettings = "data/org.gtk.innstereo.gschema.xml"
+
+if os.path.isfile(gsettings):
+    call("cp data/org.gtk.innstereo.gschema.xml pynsist_pkgs/gnome/share/glib-2.0/schemas/", shell=True)
+else:
+    print("Copying failed")
+    sys.exit()
+
+try:
+    call("glib-compile-schemas pynsist_pkgs/gnome/share/glib-2.0/schemas/", shell=True)
+except:
+    print("GSettings could not be compiled")
+    sys.exit()
+
+translations = "po/"
+
+if os.path.isdir("innstereo/locale") is False:
+    call("mkdir innstereo/locale", shell=True)
+
+for root, dirs, filenames in os.walk(translations):
+    for f in filenames:
+        print(f)
+        if f[-3:] == ".po":
+            command = "msgfmt -o po/{0}.mo po/{0}.po".format(f[:-3])
+            call(command, shell=True)
+
+            command = "cp po/{0}.mo pynsist_pkgs/gnome/share/locale/{0}/LC_MESSAGES/innstereo.mo".format(f[:-3])
+            call(command, shell=True)
+
+            command = "innstereo/locale/{0}".format(f[:-3])
+            if os.path.isdir(command) == False:
+                call("mkdir {}".format(command), shell=True)
+
+            command = "innstereo/locale/{0}/LC_MESSAGES/".format(f[:-3])
+            if os.path.isdir(command) == False:
+                call("mkdir {}".format(command), shell=True)
+
+            command = "cp po/{0}.mo innstereo/locale/{0}/LC_MESSAGES/innstereo.mo".format(f[:-3])
+            call(command, shell=True)
+
+            command = "rm po/{}.mo".format(f[:-3])
+            call(command, shell=True)
+
+
+call("python3 -m nsist installer.cfg", shell=True)
+
+sys.exit()
+#The code below is currently not used
+appname = "InnStereo"
+version = "beta3"
+shortcuts = [{"entry_point": "innstereo:startup",
+             "extra_preamble": "gnome_preamble.py",
+             "console": "false"}]
+icon = "innstereo_icon.ico"
+icon_path = os.path.abspath(os.path.join(os.path.dirname(__file__), icon))
+pkg_list = ["innstereo", "gi", "cairo", "dbus", "gnome", "pygtkcompat",
+            "numpy", "matplotlib", "six", "dateutil", "pyparsing", "scipy",
+            "mplstereonet"]
+inst_name = "InnStereo {}".format(version + " {}")
+
+installer64 = nsist.InstallerBuilder(appname, version, shortcuts,
+                                     icon=icon_path,
+                                     packages=pkg_list,
+                                     extra_files=None,
+                                     py_version="3.4.3",
+                                     py_bitness=64,
+                                     py_format="installer",
+                                     build_dir="build/nsis",
+                                     installer_name=inst_name.format("64bit"),
+                                     nsi_template=None,
+                                     exclude=None)
+
+installer64.run()
+


### PR DESCRIPTION
This PR adds the changes that make the translation work on win32. The build-files were also updated and are now closer to creating the win32 installers and translations in one run.